### PR TITLE
Changed python shebang to take environment python

### DIFF
--- a/mebs_clust.py
+++ b/mebs_clust.py
@@ -1,5 +1,4 @@
- # coding: utf-8
- #!/usr/bin/python3
+#!/usr/bin/env python3
  # -*- coding: utf-8 -*-
  #
  # ------------------------------

--- a/mebs_vis.py
+++ b/mebs_vis.py
@@ -1,5 +1,4 @@
-# fie coding: utf-8
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # ------------------------------


### PR DESCRIPTION
Hi, I had to make a very minor change to make mebs work on our system. the shebang that was present wasn`t taking the python3 that was installed as part of the conda environment i made.

Its not a vital change but it might help make it more portable across different systems - i just thought id let you see in case you thought it might be useful!

